### PR TITLE
Allow security rule ips field to contain multiple comma-separated IP addresses

### DIFF
--- a/DependencyInjection/MainConfiguration.php
+++ b/DependencyInjection/MainConfiguration.php
@@ -141,7 +141,7 @@ class MainConfiguration implements ConfigurationInterface
                             ->end()
                             ->scalarNode('host')->defaultNull()->end()
                             ->arrayNode('ips')
-                                ->beforeNormalization()->ifString()->then(function ($v) { return array($v); })->end()
+                                ->beforeNormalization()->ifString()->then(function ($v) { return preg_split('/\s*,\s*/', $v); })->end()
                                 ->prototype('scalar')->end()
                             ->end()
                             ->arrayNode('methods')

--- a/Tests/DependencyInjection/MainConfigurationTest.php
+++ b/Tests/DependencyInjection/MainConfigurationTest.php
@@ -116,4 +116,24 @@ class MainConfigurationTest extends TestCase
 
         $this->assertEquals('app.henk_checker', $processedConfig['firewalls']['stub']['user_checker']);
     }
+
+    public function testMultipleIps()
+    {
+        $config = array(
+            'access_control' => array(
+                array(
+                    'path' => '^/internal',
+                    'role' => 'IS_AUTHENTICATED_ANONYMOUSLY',
+                    'ips' => '127.0.0.1, ::1'
+                ),
+            ),
+        );
+        $config = array_merge(static::$minimalConfig, $config);
+
+        $processor = new Processor();
+        $configuration = new MainConfiguration(array(), array());
+        $processedConfig = $processor->processConfiguration($configuration, array($config));
+
+        $this->assertEquals(['127.0.0.1', '::1'],$processedConfig['access_control'][0]['ips']);
+    }
 }


### PR DESCRIPTION
In the [Symfony access control documentation](http://symfony.com/doc/master/security/access_control.html) the examples use multiple comma-separated IP addresses in the rules; those ip addresses are not split in the main configuration of the security bundle. This causes multiple comma-separated IP addresses to be seen as one IP address.
In this pull request this is fixed by splitting the IP addresses in the ips field by comma.