### PR TITLE
Fix CsrfProtectionListener argument

### DIFF
--- a/DependencyInjection/Compiler/RegisterCsrfFeaturesPass.php
+++ b/DependencyInjection/Compiler/RegisterCsrfFeaturesPass.php
@@ -42,7 +42,7 @@ class RegisterCsrfFeaturesPass implements CompilerPassInterface
         }
 
         $container->register('security.listener.csrf_protection', CsrfProtectionListener::class)
-            ->addArgument(new Reference('security.csrf.token_storage'))
+            ->addArgument(new Reference('security.csrf.token_manager'))
             ->addTag('kernel.event_subscriber')
             ->setPublic(false);
     }


### PR DESCRIPTION
Fix type error.

```
Uncaught Error: Argument 1 passed to Symfony\Component\Security\Http\EventListener\CsrfProtectionListener::__construct() must implement interface Symfony\Component\Security\Csrf\CsrfTokenManagerInterface, instance of Symfony\Component\Security\Csrf\TokenStorage\SessionTokenStorage given

Uncaught PHP Exception TypeError: "Argument 1 passed to Symfony\Component\Security\Http\EventListener\CsrfProtectionListener::__construct() must implement interface Symfony\Component\Security\Csrf\CsrfTokenManagerInterface, instance of Symfony\Component\Security\Csrf\TokenStorage\SessionTokenStorage given
```

symfony/symfony#37254