### PR TITLE
role_names variable instead of roles

### DIFF
--- a/CacheWarmer/ExpressionCacheWarmer.php
+++ b/CacheWarmer/ExpressionCacheWarmer.php
@@ -40,7 +40,7 @@ class ExpressionCacheWarmer implements CacheWarmerInterface
     public function warmUp(string $cacheDir)
     {
         foreach ($this->expressions as $expression) {
-            $this->expressionLanguage->parse($expression, ['token', 'user', 'object', 'subject', 'roles', 'request', 'trust_resolver']);
+            $this->expressionLanguage->parse($expression, ['token', 'user', 'object', 'subject', 'role_names', 'request', 'trust_resolver']);
         }
 
         return [];

--- a/Tests/CacheWarmer/ExpressionCacheWarmerTest.php
+++ b/Tests/CacheWarmer/ExpressionCacheWarmerTest.php
@@ -26,8 +26,8 @@ class ExpressionCacheWarmerTest extends TestCase
         $expressionLang->expects($this->exactly(2))
             ->method('parse')
             ->withConsecutive(
-                [$expressions[0], ['token', 'user', 'object', 'subject', 'roles', 'request', 'trust_resolver']],
-                [$expressions[1], ['token', 'user', 'object', 'subject', 'roles', 'request', 'trust_resolver']]
+                [$expressions[0], ['token', 'user', 'object', 'subject', 'role_names', 'request', 'trust_resolver']],
+                [$expressions[1], ['token', 'user', 'object', 'subject', 'role_names', 'request', 'trust_resolver']]
             );
 
         (new ExpressionCacheWarmer($expressions, $expressionLang))->warmUp('');


### PR DESCRIPTION
replaced the roles variable with role_names in order to fix cache warming

fixes #40087

https://github.com/symfony/symfony/issues/40087